### PR TITLE
feat: `latest` tag depends on semver

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           images: "ghcr.io/${{ github.repository }}"
           flavor: |
-            latest=${{ steps.latest.outputs.IS_LATEST }}
+            latest=${{ env.IS_LATEST }}
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -41,12 +41,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine `latest` status
+        run: |
+          # A tag with the format "v1.2.3" is considered a release version.
+          # Other tags (e.g. v1.2.3-dev) are considered pre-release versions.
+          export IS_LATEST=false
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "${GITHUB_REF} is a release version"
+              export IS_LATEST=true
+          else
+              echo "${GITHUB_REF} is not a release version"
+          fi
+          echo "IS_LATEST=${IS_LATEST}" >> $GITHUB_ENV
+
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: "ghcr.io/${{ github.repository }}"
+          flavor: |
+            latest=${{ steps.latest.outputs.IS_LATEST }}
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/fly.bil.toml
+++ b/fly.bil.toml
@@ -1,22 +1,23 @@
-# fly.toml app configuration file generated for galv-backend-dev-debug on 2023-12-30T07:23:48Z
+# fly.bil.toml app configuration file
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
+# This file defines the Fly deployment for the Battery Intelligence Lab in Oxford, UK.
 
-app = "galv-backend-dev"
+app = "galv-dev-backend"
 primary_region = "lhr"
 console_command = "/code/backend_django/manage.py shell"
 
 [build]
   image = "ghcr.io/galv-team/galv-backend:latest"
 
-[deploy]
+#[deploy]
 #  release_command = "/code/fly_setup.sh"
 
 [env]
 #  PORT = "80"
-  VIRTUAL_HOST = "galv-backend-dev.fly.dev"
-  FRONTEND_VIRTUAL_HOST = "http://galv-frontend-dev.fly.dev,https://galv-frontend-dev.fly.dev"
+  VIRTUAL_HOST = "galv-dev-backend.fly.dev"
+  FRONTEND_VIRTUAL_HOST = "https://galv-dev.fly.dev"
   DJANGO_SETTINGS_MODULE = "config.settings"
 #  DJANGO_SETTINGS = "dev"
   DJANGO_EMAIL_HOST = 'smtp.gmail.com'

--- a/fly.demo.toml
+++ b/fly.demo.toml
@@ -1,4 +1,4 @@
-# fly.toml app configuration file generated for galv-backend-dev-debug on 2023-12-30T07:23:48Z
+# fly.bil.toml app configuration file generated for galv-backend-dev-debug on 2023-12-30T07:23:48Z
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #

--- a/fly.stage.toml
+++ b/fly.stage.toml
@@ -1,4 +1,4 @@
-# fly.toml app configuration file generated for galv-backend-dev-debug on 2023-12-30T07:23:48Z
+# fly.bil.toml app configuration file generated for galv-backend-dev-debug on 2023-12-30T07:23:48Z
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #


### PR DESCRIPTION
Semver strings that match ^v\d+\.\d+\.\d+$ will be tagged with `latest` while other tags will not. NOTE: it's perfectly possible to release a lower version of the project as `latest` if the tag is a valid release tag.